### PR TITLE
Navigation bug fix

### DIFF
--- a/ContactsApp/ContactsApp/Views/ContactDetailsPage.xaml.cs
+++ b/ContactsApp/ContactsApp/Views/ContactDetailsPage.xaml.cs
@@ -53,7 +53,7 @@ namespace ContactsApp.Views
             Model.PhotoUrl = "ContactsApp.Images.anonymous.png";
             db.SaveContact(Model);
 
-            Navigation.PushAsync(new Views.ContactsPage());
+			Navigation.PopAsync ();
         }
 
         public async void OnDelete(object sender, EventArgs e)
@@ -64,13 +64,13 @@ namespace ContactsApp.Views
             if (answer)
             {
                 db.DeleteContact(Model.Id);
-                await Navigation.PushAsync(new Views.ContactsPage());
+				await Navigation.PopAsync ();
             }
         }
 
         public async void OnCancel(object sender, EventArgs e)
         {
-            await Navigation.PushAsync(new Views.ContactsPage());
+			await Navigation.PopAsync ();
         }
 
         public bool IsFormValid()


### PR DESCRIPTION
I would like to resolve #1 with this fix. Xamarin handles navigation like a stack. Instead of pushing a new homepage onto the stack after save/cancel/delete on the Contact Details page, this code now pops that page off the stack. This way there's no previous page when the user returns on the homepage.